### PR TITLE
FIX: Remove Discord as a Provider

### DIFF
--- a/packages/auth/env.mjs
+++ b/packages/auth/env.mjs
@@ -3,8 +3,6 @@ import { z } from "zod";
 
 export const env = createEnv({
   server: {
-    DISCORD_CLIENT_ID: z.string().min(1),
-    DISCORD_CLIENT_SECRET: z.string().min(1),
     NEXTAUTH_SECRET:
       process.env.NODE_ENV === "production"
         ? z.string().min(1)
@@ -21,8 +19,6 @@ export const env = createEnv({
   runtimeEnv: {
     NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
-    DISCORD_CLIENT_ID: process.env.DISCORD_CLIENT_ID,
-    DISCORD_CLIENT_SECRET: process.env.DISCORD_CLIENT_SECRET,
   },
   skipValidation: !!process.env.CI || !!process.env.SKIP_ENV_VALIDATION,
 });

--- a/packages/auth/index.ts
+++ b/packages/auth/index.ts
@@ -1,11 +1,8 @@
-import Discord from "@auth/core/providers/discord";
 import type { DefaultSession } from "@auth/core/types";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
 import NextAuth from "next-auth";
 
 import { db, tableCreator } from "@acme/db";
-
-import { env } from "./env.mjs";
 
 export type { Session } from "next-auth";
 
@@ -27,12 +24,7 @@ export const {
   CSRF_experimental,
 } = NextAuth({
   adapter: DrizzleAdapter(db, tableCreator),
-  providers: [
-    Discord({
-      clientId: env.DISCORD_CLIENT_ID,
-      clientSecret: env.DISCORD_CLIENT_SECRET,
-    }),
-  ],
+  providers: [],
   callbacks: {
     session: ({ session, user }) => ({
       ...session,

--- a/turbo.json
+++ b/turbo.json
@@ -35,11 +35,5 @@
       "cache": false
     }
   },
-  "globalEnv": [
-    "DATABASE_URL",
-    "DISCORD_CLIENT_ID",
-    "DISCORD_CLIENT_SECRET",
-    "NEXTAUTH_SECRET",
-    "NEXTAUTH_URL"
-  ]
+  "globalEnv": ["DATABASE_URL", "NEXTAUTH_SECRET", "NEXTAUTH_URL"]
 }


### PR DESCRIPTION
**Description**:

In this PR, the integration of Discord as a provider has been removed. This decision was made after considering the current requirements and the direction in which our application is heading. Here are the major changes:

Removed all configurations related to Discord as an authentication provider.
Cleaned up any related dependencies and libraries.
Updated the documentation to reflect this change.